### PR TITLE
Fix typos and minor improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To get a software bill of material, there are several tools that you can use. Fo
 Install the CycloneDX tool:
 
 ```powershell
-dotnet tool install --global CycloneDX`
+dotnet tool install --global CycloneDX
 ```
 
 Generate the SBOM file for the Chainguardian solution:
@@ -70,11 +70,11 @@ Starting from .NET 8 (SDK 8.0.100) the `restore` command can audit([Auditing pac
 
 With the introduction of .NET 9, the private artifact store issue is fixed. There is a new property that you can add to the `NuGet.config` file that allows you to set an audit source. By setting this property, NuGet gets its [vulnerabilityInfo resource](https://learn.microsoft.com/en-us/NuGet/api/vulnerability-info) from a different source than the configured NuGet feeds.
 
-Run the command `dotnet restore` in the root of the repository. This will restore all the packages and do a vulnerability check on all the packages that are being restored. **Check the output of the restore command** This will output a list of all the vulnerabilities that are present in the packages that are being restored as warnings in the console.
+Run the command `dotnet restore` in the root of the repository. This will restore all the packages and do a vulnerability check on all the packages that are being restored. **Check the output of the restore command.** This will output a list of all the vulnerabilities that are present in the packages that are being restored as warnings in the console.
 
 The console outputs only the direct dependencies that have vulnerabilities. In the .NET 8.0.100 SDK the `restore` command defaulted all settings that are required to do a vulnerability check:
 - `NuGetAudit` is set to `true`
-- `NuGetAuditMode` is set to `direct`*
+- `NuGetAuditMode` is set to `direct`
 - `NuGetAuditLevel` is set to `low`
 
 *In .NET 9.0.100 SDK value of `NuGetAuditMode` is changed to `all`
@@ -96,25 +96,25 @@ Now you have a situation where the restore command will output all the vulnerabi
 .NET has a build in feature that can help you with that. You can make your build fail if there are vulnerabilities present in your software. To make the actual build fail when a vulnerability is found, **add the following line to your project file**:
 
 ```xml
-<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+<WarningsAsErrors>NU1901,NU1903,NU1903,NU1904</WarningsAsErrors>
 ```
 
-Run the `dotnet restore` or `dotnet build` command and see that you are no longer able to create a succesfull build. **Now update the packages so that the build succeeds.**
+Run the `dotnet restore` or `dotnet build` command and see that you are no longer able to create a successful build. **Now update the packages so that the build succeeds.**
 
 ### Restoring packages
 Great now that we have tackled the **known** vulnerabilities in our software, let's have a look at the **hidden dangers** of the software supply chain. Before we dive into the dangers, it is good to understand how the NuGet package restore works.
 
 Using third party packages requires you to restore them via NuGet. All project dependencies that are listed in either a project file or a packages.config file are restored.
 
-Package restore first installs all the direct dependencies. These are the dependencies that are directly referenced between the <PackageReference> tags or <package> tags. After the direct dependencies all transitive packages are installed. By default, NuGet will first scan the local global packages or HTTP cache folders. If the required package isn't in the local folders, NuGet tries to downloa
+Package restore first installs all the direct dependencies. These are the dependencies that are directly referenced between the <PackageReference> tags or <package> tags. After the direct dependencies all transitive packages are installed. By default, NuGet will first scan the local global packages or HTTP cache folders. If the required package isn't in the local folders, NuGet tries to download it.
 
 What makes this behavior dangerous is that **NuGet ignores the order of package sources configured**. It first looks in the local NuGet cache, it the package is not present, it fires a request to each package source configured. It uses the package source that responds the quickest. This means that **by default, you don't have any control from what source you are restoring your packages**. If a restore fails, NuGet doesn't indicate the failure until after it checks all sources. NuGet reports a failure ony for the last source in the list. The error implies that the package wasn't present on any of the resources.
 
 ![Nuget Supply Chain Security](/assets/images/nuget-restore.drawio.png)
 
-Package resolution for transative dependencies follows a set of rules. To understand certain risks and how to mitigate them, it is important to understand how Nuget resolves transative dependencies. Before your read further, I recommend you to read the [official documentation](https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution) on how Nuget resolves transative dependencies.
+Package resolution for transitive dependencies follows a set of rules. To understand certain risks and how to mitigate them, it is important to understand how Nuget resolves transitive dependencies. Before your read further, I recommend you to read the [official documentation](https://learn.microsoft.com/en-us/nuget/concepts/dependency-resolution) on how Nuget resolves transative dependencies.
 
-Now we are going to have a look a two different types of supply chain attacks that can happen when your packages are being restored.
+Now we are going to have a look at two different types of supply chain attacks that can happen when your packages are being restored.
 
 #### Dependency confusion
 Imagine that you work at a company that uses both a public and a private Nuget feed to retrieve the packages that are used in your software projects. You have a package that is called MyCompany.Common. You have a build pipeline that builds the package and pushes it to the private Nuget feed. Via some way of research / reverse engineering, a hacker found the name of your private image used internally (MyCompany.Common). The hacker then creates a package with the same name, version and adds some malware/backdoor to the source code and uploads it to the public Nuget feed.
@@ -124,11 +124,11 @@ Because of the way a nuget restore works (it uses the first source that responds
 For example, you are using the package MyCompany.Common with version `1.0.0` and you reference it in your project file like this <PackageReference Include="MyCompany.Common" Version="1.0.*" />. You have a connection to your own private feed and the public Nuget feed. The hacker uploads a package with the name MyCompany.Common with version 1.0.1 to the public Nuget feed. When you run a restore, NuGet will restore the package of the hacker because of the resolution rules. You can **unintentionally** introduce a new way for your software to be vulnerable for a supply chain attack. It is good to understand how [Nuget semantic versioning works](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#references-in-project-files-packagereference) and what the risks are of the way you reference your packages in your project file.
 
 ##### Mitigations
-**NOTE**: before you perform the next excersices make sure that you run the command ``nuget locals all -clear`. This will clear you local cached packages, so that you can see the effect of the mitigations that you are going to do. If you don't run this command, NuGet will use the cached packages and you will not see the effect of the mitigations.
+**NOTE**: before you perform the next exercise make sure that you run the command `nuget locals all -clear`. This will clear you local cached packages, so that you can see the effect of the mitigations that you are going to do. If you don't run this command, NuGet will use the cached packages and you will not see the effect of the mitigations.
 
 By default, having both a public and a private feed is a risk. I would recommend to **only use a private feed**. This way you (your company) has control over the packages that are available to your software projects. You can configure Nuget to only use the private feed. Configuring NuGet to use a certain package source is done via the [`nuget.config` file](https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file).
 
-**Excersice**: Create a `nuget.config` file in the root of the repository and configure NuGet to use the public NuGet feed.
+**Exercise**: Create a `nuget.config` file in the root of the repository and configure NuGet to use the public NuGet feed.
 
 If for some reason you use / require a public feed next to your private feed, there are a few things that you can do to mitigate the risk of dependency confusion. The first thing that you can (if you publish a package yourself) is [claim the prefix](https://learn.microsoft.com/en-us/nuget/nuget-org/id-prefix-reservation) of your packages. This means that you claim the prefix of your packages on the public Nuget feed. This way, the public Nuget feed will not allow anyone to upload a package with the same prefix as your packages. This will prevent the hacker from uploading a package with the same name as your package. In the example of `MyCompany.Common`, you would claim the prefix `MyCompany`.
 
@@ -136,11 +136,11 @@ We are **not going** to do this in this workshop, but it is good to know that th
 
 The second thing that you can do is use the `nuget.config` file to configure the package sources that you want to use. You can add a `packageSourceMapping` element to the `nuget.config` file. This element allows you to map a package source to a specific feed. This way you can configure NuGet to only use the private feed for the package `MyCompany.Common`.
 
-**Excersice**: Add the package source mapping to the `nuget.config` file and configure NuGet to pull the required packages from the configured feed. 
+**Exercise**: Add the package source mapping to the `nuget.config` file and configure NuGet to pull the required packages from the configured feed. 
 
 A third thing that you can do is to **configure trusted signers**. This way you can configure NuGet to only accept packages that are signed by a trusted signer. This way you can make sure that the packages that are being restored are coming from a trusted source. This is a good way to mitigate the risk of dependency confusion.
 
-**Excersice**: Configure trusted signers in the `nuget.config` file.
+**Exercise**: Configure trusted signers in the `nuget.config` file.
 
 To protect your software from the serious risks of dependency confusion, it's essential to take proactive measures. Start by configuring Nuget to only use a private feed, ensuring control over the packages integrated into your projects. If you must use a public feed, mitigate risks by claiming your package prefix, setting up package source mapping, and configuring trusted signers. Taking these steps will significantly reduce the likelihood of malicious code infiltrating your software supply chain. Act now by reviewing and updating your Nuget configurations to safeguard your projects against these potential vulnerabilities.
 
@@ -184,7 +184,7 @@ You must enable the lock file by adding the following line to your project file:
 
 This will generate a lock file with all your resolved dependencies in it. You must commit/check-in this lock file to your source control so that it is always available for `restore`.NuGet does a quick check to see if there were any changes in the package dependencies as mentioned in the project file (or dependent projects’ files) and if there were no changes, it just restores the packages mentioned in the lock file without re-evaluating the full package graph. NuGet detects a change in the defined dependencies as enumerated in the project file(s), it re-evaluates the package graph and updates the lock file to reflect the new package graph applicable for the project. This is the default mode and is useful when you are in a development environment actively modifying your package and project dependencies.
 
-Reading this, I hear you think. If the dependency graph is re-evaualted when there are changes in the project file, how does this protect me from an infiltrated build system? Well, by default it doesn't. But you can tell the dotnet restore command to run in a `locked-mode`. You can run the `dotnet restore` command with the `--locked-mode` flag. This will make sure that the lock file is used to restore the packages and that the lock file is not updated. This way you can make sure that the packages that are restored are the same as the packages that are restored on your local machine.
+Reading this, I hear you think. If the dependency graph is re-evaluated when there are changes in the project file, how does this protect me from an infiltrated build system? Well, by default it doesn't. But you can tell the dotnet restore command to run in a `locked-mode`. You can run the `dotnet restore` command with the `--locked-mode` flag. This will make sure that the lock file is used to restore the packages and that the lock file is not updated. This way you can make sure that the packages that are restored are the same as the packages that are restored on your local machine.
 
 Beside the `--locked-mode` flag you can also use the following configuration in your project file:
 ```XML
@@ -205,7 +205,7 @@ To set the [`ContinuousIntegrationBuild`](https://learn.microsoft.com/en-us/dotn
 </PropertyGroup>
 ```
 
-Excersice: Add the `ContinuousIntegrationBuild` property to the project file. If . Check the output of the command and see that the property is set to true.
+Exercise: Add the `ContinuousIntegrationBuild` property to the project file. If . Check the output of the command and see that the property is set to true.
 
 To make your build even more reliable, [there a even more project properties](https://github.com/dotnet/reproducible-builds/blob/main/Documentation/Reproducible-MSBuild/Techniques/toc.md) that you can set. These properties are:
 
@@ -233,7 +233,7 @@ To make your build even more reliable, [there a even more project properties](ht
 </PropertyGroup>
 ```
 
-All these settings are good to understand and now what they do. To make this more easy for you, Microsoft created a [NuGet package 'ReproducibleBuilds'](https://github.com/dotnet/reproducible-builds/tree/main) that does all this settings for you. 
+All these settings are good to understand and now what they do. To make this easier for you, Microsoft created a [NuGet package 'ReproducibleBuilds'](https://github.com/dotnet/reproducible-builds/tree/main) that does all these settings for you. 
 
 ## Conclusion
 In conclusion, securing your NuGet supply chain is essential to safeguarding your software projects from the growing threats of supply chain attacks. The increasing reliance on third-party packages introduces vulnerabilities that can be exploited by malicious actors, as seen in high-profile incidents like the Log4J vulnerability and SolarWinds attack. As a consumer, it's crucial to implement robust security practices, including thorough dependency management, package restoration controls, and proactive measures against dependency confusion and typosquatting.


### PR DESCRIPTION
This PR fixes some minor typographical and grammatical errors. 

It also changes the `TreatWarningsAsErrors` setting to `WarningsAsErrors`, which only includes low to critical vulnerabilities to cause a build failure.